### PR TITLE
[PKG-2779] libsolv 0.7.24

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,3 @@
-set "CFLAGS= -MD"
-echo %CFLAGS%
-
-set "CXXFLAGS= -MD"
-echo %CXXFLAGS%
-
 mkdir build
 cd build
 
@@ -15,7 +9,9 @@ cmake -G "Ninja" ^
       -D MULTI_SEMANTICS=ON ^
       -D WITHOUT_COOKIEOPEN=ON ^
       -D CMAKE_BUILD_TYPE=Release ^
+      -D CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" ^
       -D DISABLE_SHARED=OFF ^
+      -D ENABLE_STATIC=OFF ^
       -D ENABLE_PCRE2=ON ^
       ..
 if errorlevel 1 exit 1
@@ -35,6 +31,7 @@ cmake -G "Ninja" ^
       -D MULTI_SEMANTICS=ON ^
       -D WITHOUT_COOKIEOPEN=ON ^
       -D CMAKE_BUILD_TYPE=Release ^
+      -D CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" ^
       -D ENABLE_STATIC=ON ^
       -D DISABLE_SHARED=ON ^
       -D ENABLE_PCRE2=ON ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,15 +9,15 @@ cd build || exit 1
 # Generate the build files.
 echo "Generating the build files..."
 cmake .. ${CMAKE_ARGS} \
-      -GNinja \
-      -DCMAKE_PREFIX_PATH=$PREFIX \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DENABLE_CONDA=ON \
-      -DMULTI_SEMANTICS=ON \
-      -DENABLE_PCRE2=ON \
-      -DENABLE_STATIC=ON
+-GNinja \
+-DCMAKE_PREFIX_PATH=$PREFIX \
+-DCMAKE_INSTALL_PREFIX=$PREFIX \
+-DCMAKE_BUILD_TYPE=Release \
+-DCMAKE_INSTALL_LIBDIR=lib \
+-DENABLE_CONDA=ON \
+-DMULTI_SEMANTICS=ON \
+-DENABLE_PCRE2=ON \
+-DENABLE_STATIC=ON
 
 
 # Build.

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -9,8 +9,8 @@ ninja install || exit 1
 
 if [[ "$PKG_NAME" == *static ]]
 then
-	# relying on conda to dedup package
-	echo "Doing nothing"
+    # relying on conda to dedup package
+    echo "Doing nothing"
 else
-	rm -rf ${PREFIX}/lib/*a
+    rm -rf ${PREFIX}/lib/*a
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ requirements:
     - patch     # [not win]
     - ninja
     - cmake
-    - pkg-config
   host:
+    - pkg-config
     - zlib
     - pcre2
 
@@ -44,8 +44,8 @@ outputs:
         - {{ compiler('cxx') }}
         - ninja
         - cmake
-        - pkg-config
       host:
+        - pkg-config
         - zlib
         - pcre2
     test:
@@ -74,8 +74,8 @@ outputs:
         - {{ compiler('cxx') }}
         - ninja
         - cmake
-        - pkg-config
       host:
+        - pkg-config
         - zlib
         - pcre2
         - {{ pin_subpackage("libsolv", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,26 @@
-{% set version = "0.7.22" %}
-{% set sha256 = "968aef452b5493751fa0168cd58745a77c755e202a43fe8d549d791eb16034d5" %}
-{% set build_number = "0" %}
+{% set name = "libsolv" %}
+{% set version = "0.7.24" %}
 
 package:
-  name: libsolv-suite
+  name: {{ name|lower }}-suite
   version: {{ version }}
 
 source:
-  url: https://github.com/openSUSE/libsolv/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/openSUSE/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 62743265222a729c7fe94c40f7b90ccc1ac5568f5ee6df46884e7ce3c16c78c7
   patches:
     - win_export_and_static_build.patch  # [win]
     - conda_variant_priorization.patch
     - pcre2-compat.patch                 # See https://github.com/openSUSE/libsolv/pull/506
+    - no_error_subdir_mismatch.patch
 
 build:
-  number: {{ build_number }}
+  number: 0
   run_exports:
     - {{ pin_subpackage('libsolv', max_pin='x.x') }}
   ignore_run_exports:  # [win]
     - zlib             # [win]
+
 requirements:
   build:
     - {{ compiler('c') }}
@@ -28,8 +29,8 @@ requirements:
     - patch     # [not win]
     - ninja
     - cmake
-  host:
     - pkg-config
+  host:
     - zlib
     - pcre2
 
@@ -43,8 +44,8 @@ outputs:
         - {{ compiler('cxx') }}
         - ninja
         - cmake
-      host:
         - pkg-config
+      host:
         - zlib
         - pcre2
     test:
@@ -53,12 +54,17 @@ outputs:
         - test -f ${PREFIX}/lib/libsolvext${SHLIB_EXT}  # [unix]
         - test -f ${PREFIX}/lib/libsolv.so.1            # [linux]
         - test -f ${PREFIX}/include/solv/repo.h         # [unix]
-        - if exist %LIBRARY_INC%\solv\repo.h (exit 0) else (exit 1)  # [win]
-        - if exist %LIBRARY_LIB%\solv.lib (exit 0) else (exit 1)     # [win]
-        - if exist %LIBRARY_LIB%\solvext.lib (exit 0) else (exit 1)  # [win]
-        - if exist %LIBRARY_BIN%\solv.dll (exit 0) else (exit 1)     # [win]
+        - if not exist %LIBRARY_INC%\solv\repo.h (exit 1)     # [win]
+        - if not exist %LIBRARY_BIN%\solv.dll (exit 1)        # [win]
+        - if not exist %LIBRARY_LIB%\solv.lib (exit 1)        # [win]
+        - if not exist %LIBRARY_BIN%\solvext.dll (exit 1)     # [win]
+        - if not exist %LIBRARY_LIB%\solvext.lib (exit 1)     # [win]
+        - if exist %LIBRARY_LIB%\solv_static.lib (exit 1)     # [win]
+        - if exist %LIBRARY_LIB%\solvext_static.lib (exit 1)  # [win]
+        # Running the executables
         - dumpsolv.exe -h  # [win]
         - dumpsolv -h      # [unix]
+
   - name: libsolv-static
     script: install.sh          # [unix]
     script: install_static.bat  # [win]
@@ -68,8 +74,8 @@ outputs:
         - {{ compiler('cxx') }}
         - ninja
         - cmake
-      host:
         - pkg-config
+      host:
         - zlib
         - pcre2
         - {{ pin_subpackage("libsolv", exact=True) }}
@@ -77,10 +83,10 @@ outputs:
         - {{ pin_subpackage("libsolv", exact=True) }}
     test:
       commands:
-        - test -f ${PREFIX}/lib/libsolv.a     # [unix]
-        - test -f ${PREFIX}/lib/libsolvext.a  # [unix]
-        - if exist %LIBRARY_LIB%\solv_static.lib (exit 0) else (exit 1)     # [win]
-        - if exist %LIBRARY_LIB%\solvext_static.lib (exit 0) else (exit 1)  # [win]
+        - test -f "${PREFIX}/lib/libsolv.a"     # [unix]
+        - test -f "${PREFIX}/lib/libsolvext.a"  # [unix]
+        - if not exist %LIBRARY_LIB%\solv_static.lib (exit 1)     # [win]
+        - if not exist %LIBRARY_LIB%\solvext_static.lib (exit 1)  # [win]
 
 about:
   home: https://github.com/openSUSE/libsolv
@@ -88,10 +94,10 @@ about:
   license_family: BSD
   license_file: LICENSE.BSD
   summary: Library for solving packages and reading repositories
-  description: libsolv, a free package dependency solver using a satisfiability algorithm.
+  description: |
+    libsolv, a free package dependency solver using a satisfiability algorithm.
   dev_url: https://github.com/openSUSE/libsolv
   doc_url: https://github.com/openSUSE/libsolv/tree/master/doc
-  doc_src_url: https://github.com/openSUSE/libsolv/tree/master/doc
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - ninja
     - cmake
   host:
+    # pkg-config is placed in host because in build it is not available for win64
     - pkg-config
     - zlib
     - pcre2
@@ -45,6 +46,7 @@ outputs:
         - ninja
         - cmake
       host:
+        # pkg-config is placed in host because in build it is not available for win64
         - pkg-config
         - zlib
         - pcre2

--- a/recipe/no_error_subdir_mismatch.patch
+++ b/recipe/no_error_subdir_mismatch.patch
@@ -1,0 +1,24 @@
+diff --git a/ext/repo_conda.c b/ext/repo_conda.c
+index 9211cbe..c471039 100644
+--- a/ext/repo_conda.c
++++ b/ext/repo_conda.c
+@@ -314,8 +314,7 @@ parse_package(struct parsedata *pd, struct solv_jsonparser *jp, char *kfn, char
+   /* if we have a global subdir make sure that it matches */
+   if (subdir && pd->subdir && strcmp(subdir, pd->subdir) != 0)
+     {
+-      pd->error = "subdir mismatch";
+-      return JP_ERROR;
++      printf("subdir mismatch\n");
+     }
+ 
+   if (fn || kfn)
+@@ -402,8 +401,7 @@ parse_info(struct parsedata *pd, struct solv_jsonparser *jp)
+ 	    pd->subdir = strdup(jp->value);
+ 	  else if (strcmp(pd->subdir, jp->value))
+ 	    {
+-	      pd->error = "subdir mismatch";
+-	      return JP_ERROR;
++	      printf("warning: subdir mismatch\n");
+ 	    }
+ 	}
+     }


### PR DESCRIPTION
Changelog: https://github.com/openSUSE/libsolv/blob/0.7.24/NEWS
License: https://github.com/openSUSE/libsolv/blob/0.7.24/LICENSE.BSD
Requirements: https://github.com/openSUSE/libsolv/blob/0.7.24/CMakeLists.txt

Actions:
1. Update build scripts following the conda-forge recipe
2. Add a patch from the c-f recipe [no_error_subdir_mismatch.patch](https://github.com/AnacondaRecipes/libsolv-feedstock/pull/3/files#diff-1fd2bf711be515b4e9845584a71a330ac8774ed81a33831967968793a7f550c4)
3. Add a comment about why `pkg-config` is placed in `host`
4. Refactor test commands

Notes:
- `mamba 2023.09.05` (`libmamba/libmambapy 1.5.1`) requires **libsolv >=0.7.23**, see https://github.com/AnacondaRecipes/mamba-feedstock/pull/11#issuecomment-1709987337