### PR TITLE
Rebuild libsolv and libsolv-static against pcre2 10.46 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/pcre2-compat.patch
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('libsolv', max_pin='x.x') }}
   ignore_run_exports:  # [win]
@@ -25,15 +25,13 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - m2-patch  # [win]
-    - patch     # [not win]
     - ninja
     - cmake
   host:
     # pkg-config is placed in host because in build it is not available for win64
     - pkg-config
-    - zlib
-    - pcre2
+    - zlib {{ zlib }}
+    - pcre2 {{ pcre2 }}
 
 outputs:
   - name: libsolv
@@ -48,8 +46,8 @@ outputs:
       host:
         # pkg-config is placed in host because in build it is not available for win64
         - pkg-config
-        - zlib
-        - pcre2
+        - zlib {{ zlib }}
+        - pcre2 {{ pcre2 }}
     test:
       commands:
         - test -f ${PREFIX}/lib/libsolv${SHLIB_EXT}     # [unix]
@@ -78,8 +76,8 @@ outputs:
         - cmake
       host:
         - pkg-config
-        - zlib
-        - pcre2
+        - zlib {{ zlib }}
+        - pcre2 {{ pcre2 }}
         - {{ pin_subpackage("libsolv", exact=True) }}
       run:
         - {{ pin_subpackage("libsolv", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config
@@ -38,6 +39,7 @@ outputs:
     script: install_dynamic.bat  # [win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config
@@ -68,6 +70,7 @@ outputs:
     script: install_static.bat  # [win]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - pkg-config
     - ninja
     - cmake
   host:
-    # pkg-config is placed in host because in build it is not available for win64
-    - pkg-config
     - zlib {{ zlib }}
     - pcre2 {{ pcre2 }}
 
@@ -41,11 +40,10 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - pkg-config
         - ninja
         - cmake
       host:
-        # pkg-config is placed in host because in build it is not available for win64
-        - pkg-config
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
     test:
@@ -72,10 +70,10 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - pkg-config
         - ninja
         - cmake
       host:
-        - pkg-config
         - zlib {{ zlib }}
         - pcre2 {{ pcre2 }}
         - {{ pin_subpackage("libsolv", exact=True) }}


### PR DESCRIPTION
libsolv 0.7.30

**Destination channel:** Defaults

### Links

- [PKG-10078](https://anaconda.atlassian.net/browse/PKG-10078)
- [Upstream repository](https://github.com/openSUSE/libsolv/tree/0.7.30)

### Explanation of changes:

- Increase build number
- Add pinnings to host
- Satisfy linter


[PKG-10078]: https://anaconda.atlassian.net/browse/PKG-10078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ