### PR TITLE
libsolv 0.7.37 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,10 @@ source:
   url: https://github.com/openSUSE/{{ name }}/archive/{{ version }}.tar.gz
   sha256: ad6a38624dde26fc59c41427608536c443b76f90dcb6bb96c2e70b8e3ee20419
   patches:
-    - patches/win_export_and_static_build.patch  # [win]
     - patches/conda_variant_priorization.patch
     - patches/no_error_subdir_mismatch.patch
     - patches/pcre2-compat.patch
+    - patches/win_export_and_static_build.patch  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "libsolv" %}
-{% set version = "0.7.30" %}
+{% set version = "0.7.37" %}
 
 package:
-  name: {{ name|lower }}-suite
+  name: {{ name }}-suite
   version: {{ version }}
 
 source:
   url: https://github.com/openSUSE/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: ce4aa2f0e3c5c9ab99dced6a1810af3f670f1b98892394edc68ccabe7b272133
+  sha256: ad6a38624dde26fc59c41427608536c443b76f90dcb6bb96c2e70b8e3ee20419
   patches:
     - patches/win_export_and_static_build.patch  # [win]
     - patches/conda_variant_priorization.patch
@@ -15,7 +15,7 @@ source:
     - patches/pcre2-compat.patch
 
 build:
-  number: 2
+  number: 0
   run_exports:
     - {{ pin_subpackage('libsolv', max_pin='x.x') }}
   ignore_run_exports:  # [win]
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config
-    - ninja
+    - ninja-base
     - cmake
   host:
     - zlib {{ zlib }}
@@ -43,7 +43,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config
-        - ninja
+        - ninja-base
         - cmake
       host:
         - zlib {{ zlib }}
@@ -74,7 +74,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config
-        - ninja
+        - ninja-base
         - cmake
       host:
         - zlib {{ zlib }}

--- a/recipe/patches/pcre2-compat.patch
+++ b/recipe/patches/pcre2-compat.patch
@@ -1,19 +1,32 @@
+From 017f035812ab846f4a4a3b6921c877621436f160 Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Mon, 25 May 2026 04:32:10 -0700
+Subject: [PATCH] PCRE2 compatibility patch
+
+---
+ CMakeLists.txt       | 14 +++++++++++++-
+ src/CMakeLists.txt   |  2 ++
+ src/conda.c          | 13 ++++++++++---
+ src/repodata.c       |  7 +++++++
+ src/solvversion.h.in |  1 +
+ 5 files changed, 33 insertions(+), 4 deletions(-)
+
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 3541f496..a2ec792c 100644
+index 5ba5ed5..8c3b765 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -33,6 +33,7 @@ OPTION (ENABLE_APPDATA "Build with AppStream appdata support?" OFF)
-
+@@ -35,6 +35,7 @@ OPTION (ENABLE_APPDATA "Build with AppStream appdata support?" OFF)
+ 
  OPTION (MULTI_SEMANTICS "Build with support for multiple distribution types?" OFF)
-
+ 
 +OPTION (ENABLE_PCRE2 "Build with PCRE2 as the regex engine" OFF)
  OPTION (ENABLE_LZMA_COMPRESSION "Build with lzma/xz compression support?" OFF)
  OPTION (ENABLE_BZIP2_COMPRESSION "Build with bzip2 compression support?" OFF)
  OPTION (ENABLE_ZSTD_COMPRESSION "Build with zstd compression support?" OFF)
-@@ -203,6 +204,13 @@ IF (MULTI_SEMANTICS)
+@@ -212,6 +213,13 @@ IF (MULTI_SEMANTICS)
  MESSAGE (STATUS "Enabling multi dist support")
  ENDIF (MULTI_SEMANTICS)
-
+ 
 +IF (ENABLE_PCRE2)
 +  MESSAGE (STATUS "Enabling PCRE2 regex engine")
 +  FIND_PACKAGE (PkgConfig REQUIRED)
@@ -24,18 +37,19 @@ index 3541f496..a2ec792c 100644
  IF (ENABLE_RPMDB)
  SET (ENABLE_RPMPKG ON)
  ENDIF (ENABLE_RPMDB)
-@@ -313,7 +321,7 @@ FOREACH (VAR
-   ENABLE_HELIXREPO ENABLE_MDKREPO ENABLE_ARCHREPO ENABLE_DEBIAN ENABLE_HAIKU
+@@ -318,7 +326,8 @@ FOREACH (VAR
    ENABLE_ZLIB_COMPRESSION ENABLE_LZMA_COMPRESSION ENABLE_BZIP2_COMPRESSION
    ENABLE_ZSTD_COMPRESSION ENABLE_ZCHUNK_COMPRESSION ENABLE_PGPVRFY ENABLE_APPDATA
+   ENABLE_APK
 -  WITH_SYSTEM_ZCHUNK)
-+  WITH_SYSTEM_ZCHUNK ENABLE_PCRE2)
++  WITH_SYSTEM_ZCHUNK
++  ENABLE_PCRE2)
    IF(${VAR})
      ADD_DEFINITIONS (-D${VAR}=1)
      SET (SWIG_FLAGS ${SWIG_FLAGS} -D${VAR})
-@@ -411,6 +419,9 @@ SET (SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES} ${EXPAT_LIBRARY})
+@@ -417,6 +426,9 @@ SET (SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES} ${EXPAT_LIBRARY})
  ENDIF (WITH_LIBXML2 )
-
+ 
  ENDIF (ENABLE_RPMMD OR ENABLE_SUSEREPO OR ENABLE_APPDATA OR ENABLE_COMPS OR ENABLE_HELIXREPO OR ENABLE_MDKREPO)
 +IF (ENABLE_PCRE2)
 +  SET (SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES} ${PCRE2_LINK_LIBRARIES})
@@ -44,11 +58,11 @@ index 3541f496..a2ec792c 100644
  SET (SYSTEM_LIBRARIES ${SYSTEM_LIBRARIES} ${ZLIB_LIBRARY})
  ENDIF (ENABLE_ZLIB_COMPRESSION)
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index bbf30bac..9a429fe4 100644
+index 812abe6..032829c 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -49,8 +49,10 @@ ENDIF (HAVE_LINKER_VERSION_SCRIPT)
-
+@@ -54,8 +54,10 @@ ENDIF (HAVE_LINKER_VERSION_SCRIPT)
+ 
  IF (DISABLE_SHARED)
      ADD_LIBRARY (libsolv STATIC ${libsolv_SRCS})
 +    TARGET_LINK_LIBRARIES(libsolv ${SYSTEM_LIBRARIES})
@@ -56,10 +70,10 @@ index bbf30bac..9a429fe4 100644
      ADD_LIBRARY (libsolv SHARED ${libsolv_SRCS})
 +    TARGET_LINK_LIBRARIES(libsolv ${SYSTEM_LIBRARIES})
  ENDIF (DISABLE_SHARED)
-
+ 
  IF (WIN32)
 diff --git a/src/conda.c b/src/conda.c
-index 6f6a65a6..ff91e13a 100644
+index 6f6a65a..ff91e13 100644
 --- a/src/conda.c
 +++ b/src/conda.c
 @@ -17,7 +17,14 @@
@@ -74,12 +88,12 @@ index 6f6a65a6..ff91e13a 100644
 +#else
  #include <regex.h>
 +#endif
-
+ 
  #include "pool.h"
  #include "repo.h"
 @@ -574,7 +581,7 @@ pool_conda_matchspec(Pool *pool, const char *name)
    int haveglob = 0;
-
+ 
    /* ignore channel and namespace for now */
 -  if ((p2 = strrchr(name, ':')))
 +  if ((p2 = strrchr(name, ':')) && (p2 < strchr(name, ' ')))
@@ -100,7 +114,7 @@ index 6f6a65a6..ff91e13a 100644
  	      p--;
  	      continue;	/* special case space: it may be in the build */
 diff --git a/src/repodata.c b/src/repodata.c
-index 72f03d48..24167170 100644
+index 9c26503..aa99fc1 100644
 --- a/src/repodata.c
 +++ b/src/repodata.c
 @@ -22,7 +22,14 @@
@@ -115,18 +129,21 @@ index 72f03d48..24167170 100644
 +#else
  #include <regex.h>
 +#endif
-
+ 
  #include "repo.h"
  #include "pool.h"
 diff --git a/src/solvversion.h.in b/src/solvversion.h.in
-index da0ad743..35d33b92 100644
+index 6c766de..46f7922 100644
 --- a/src/solvversion.h.in
 +++ b/src/solvversion.h.in
 @@ -30,6 +30,7 @@ extern const char solv_toolversion[];
  #cmakedefine LIBSOLV_FEATURE_MULTI_SEMANTICS
  #cmakedefine LIBSOLV_FEATURE_CONDA
-
+ 
 +#cmakedefine LIBSOLVEXT_FEATURE_PCRE2
  #cmakedefine LIBSOLVEXT_FEATURE_RPMPKG
  #cmakedefine LIBSOLVEXT_FEATURE_RPMDB
  #cmakedefine LIBSOLVEXT_FEATURE_RPMDB_BYRPMHEADER
+-- 
+2.39.5 (Apple Git-154)
+

--- a/recipe/patches/win_export_and_static_build.patch
+++ b/recipe/patches/win_export_and_static_build.patch
@@ -1,24 +1,22 @@
-diff --git a/src/repo_write.c b/src/repo_write.c
-index a73eebff..9e0622e3 100644
---- a/src/repo_write.c
-+++ b/src/repo_write.c
-@@ -188,7 +188,7 @@ write_compressed_blob(Repodata *data, void *blob, int len)
- 	  write_u8(data, clen);
- 	  write_blob(data, cpage, clen);
- 	}
--      blob += chunk;
-+      blob = (char*) blob + chunk;
-       len -= chunk;
-     }
- }
+From 27d655687fe63cccd678b554e48bbb8fe660f2fb Mon Sep 17 00:00:00 2001
+From: Andrii Osipov <aosipov@anaconda.com>
+Date: Mon, 25 May 2026 04:47:45 -0700
+Subject: [PATCH] win export and static build
+
+---
+ src/solvversion.c    | 10 +++++-----
+ src/solvversion.h.in | 17 ++++++++++++-----
+ win32/CMakeLists.txt |  4 +++-
+ 3 files changed, 20 insertions(+), 11 deletions(-)
+
 diff --git a/src/solvversion.c b/src/solvversion.c
-index 51d57a63..608d813b 100644
+index 51d57a6..608d813 100644
 --- a/src/solvversion.c
 +++ b/src/solvversion.c
 @@ -7,8 +7,8 @@
-
+ 
  #include "solvversion.h"
-
+ 
 -const char solv_version[] = LIBSOLV_VERSION_STRING;
 -int solv_version_major = LIBSOLV_VERSION_MAJOR;
 -int solv_version_minor = LIBSOLV_VERSION_MINOR;
@@ -30,13 +28,13 @@ index 51d57a63..608d813b 100644
 +SOLV_API int solv_version_patch = LIBSOLV_VERSION_PATCH;
 +SOLV_API const char solv_toolversion[] = LIBSOLV_TOOLVERSION;
 diff --git a/src/solvversion.h.in b/src/solvversion.h.in
-index da0ad743..23026626 100644
+index 46f7922..46d2b40 100644
 --- a/src/solvversion.h.in
 +++ b/src/solvversion.h.in
 @@ -19,11 +19,18 @@
  #define LIBSOLV_VERSION_PATCH @LIBSOLV_PATCH@
  #define LIBSOLV_VERSION (LIBSOLV_VERSION_MAJOR * 10000 + LIBSOLV_VERSION_MINOR * 100 + LIBSOLV_VERSION_PATCH)
-
+ 
 -extern const char solv_version[];
 -extern int solv_version_major;
 -extern int solv_version_minor;
@@ -54,20 +52,14 @@ index da0ad743..23026626 100644
 +SOLV_API extern int solv_version_minor;
 +SOLV_API extern int solv_version_patch;
 +SOLV_API extern const char solv_toolversion[];
-
+ 
  #cmakedefine LIBSOLV_FEATURE_LINKED_PKGS
  #cmakedefine LIBSOLV_FEATURE_COMPLEX_DEPS
 diff --git a/win32/CMakeLists.txt b/win32/CMakeLists.txt
-index 9a87af7b..161f0725 100644
+index 9a87af7..f704a79 100644
 --- a/win32/CMakeLists.txt
 +++ b/win32/CMakeLists.txt
-@@ -1,4 +1,5 @@
- INCLUDE_DIRECTORIES (${PROJECT_SOURCE_DIR}/win32)
-+
- SET (WIN32_COMPAT_SOURCES
-   ${PROJECT_SOURCE_DIR}/win32/fnmatch.c
-   ${PROJECT_SOURCE_DIR}/win32/getopt.c
-@@ -6,4 +7,6 @@ SET (WIN32_COMPAT_SOURCES
+@@ -6,4 +6,6 @@ SET (WIN32_COMPAT_SOURCES
    ${PROJECT_SOURCE_DIR}/win32/regexec.c
    ${PROJECT_SOURCE_DIR}/win32/strfncs.c
    ${PROJECT_SOURCE_DIR}/win32/tre-mem.c
@@ -76,4 +68,6 @@ index 9a87af7b..161f0725 100644
 +)
 +
 +INSTALL (FILES ${PROJECT_SOURCE_DIR}/win32/config.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/solv")
-\ No newline at end of file
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
libsolv 0.7.37 

**Destination channel:** Defaults

### Links

- [PKG-13947]
- dev_url:        https://github.com/openSUSE/libsolv/tree/0.7.37
- conda_forge:    https://github.com/conda-forge/libsolv-feedstock

### Explanation of changes:

- new version number


[PKG-13947]: https://anaconda.atlassian.net/browse/PKG-13947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ