### PR TITLE
libsolv 0.7.39

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libsolv" %}
-{% set version = "0.7.37" %}
+{% set version = "0.7.39" %}
 
 package:
   name: {{ name }}-suite
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/openSUSE/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: ad6a38624dde26fc59c41427608536c443b76f90dcb6bb96c2e70b8e3ee20419
+  sha256: 2a74cbf1e49984cb01f75ac4b19a237f24de6ce199766858aeb9ab3aae2b95fa
   patches:
     - patches/conda_variant_priorization.patch
     - patches/no_error_subdir_mismatch.patch


### PR DESCRIPTION
libsolv 0.7.39

**Destination channel:** Defaults

### Links

- [PKG-14937](https://anaconda.atlassian.net/browse/PKG-14937)
- dev_url:        https://github.com/openSUSE/libsolv/tree/0.7.39
- conda_forge:    https://github.com/conda-forge/libsolv-feedstock

### Explanation of changes:

- new version number

Addresses:
- https://app.opencve.io/cve/CVE-2026-48863
- https://nvd.nist.gov/vuln/detail/CVE-2026-9150
- https://nvd.nist.gov/vuln/detail/CVE-2026-9149


[PKG-14937]: https://anaconda.atlassian.net/browse/PKG-14937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ